### PR TITLE
Add Android ANT Legacy Compatibility XML to permissions

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -256,6 +256,7 @@ PRODUCT_COPY_FILES += \
 
 # Permissions
 PRODUCT_COPY_FILES += \
+    external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml:system/etc/permissions/com.dsi.ant.antradio_library.xml \
     frameworks/native/data/etc/android.hardware.audio.low_latency.xml:system/etc/permissions/android.hardware.audio.low_latency.xml \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:system/etc/permissions/android.hardware.camera.flash-autofocus.xml \


### PR DESCRIPTION
This non-functional library is required to be installed on the system for legacy
compatibility purposes and its presence indicates built-in ANT support.

**I hope this fixes ANT+ support on this device**